### PR TITLE
Set num_txs in block header

### DIFF
--- a/src/components/PageBlock.vue
+++ b/src/components/PageBlock.vue
@@ -156,6 +156,7 @@ export default {
       this.jsonUrl = `${this.blockchain.rpc}/block?height=${this.$route.params.block}`
       let json = await axios.get(this.jsonUrl)
       this.block = json.data.result.block
+      this.block.header.num_txs = parseInt(this.block.data.txs.length)
       this.block.header.height = parseInt(this.block.header.height)
     },
 


### PR DESCRIPTION
The block header expects the field `num_txs`, which our RPC endpoint does not send. We can use the actual transactions:
```
      "data": {
        "txs": [
          "ey...",
          "ey..."
        ]
      },
```
and count the entries.