### PR TITLE
Fix: TextDecoderLite is not defined

### DIFF
--- a/src/components/PageBlocks.vue
+++ b/src/components/PageBlocks.vue
@@ -20,7 +20,7 @@ tm-page(title='Blocks')
         td
           router-link(:to="`/blocks/${x.header.height}`")
             | {{ num.prettyInt(x.header.height) }}
-        td(:class="{ noTxs: parseInt(x.header.num_txs) === 0 }") {{ num.prettyInt(x.header.num_txs) }}
+        td(:class="{ noTxs: parseInt(x.num_txs) === 0 }") {{ num.prettyInt(x.num_txs) }}
         td {{ readableDate(x.header.time) }}
         td {{ x.header.last_commit_hash }}
 </template>

--- a/src/scripts/tx.js
+++ b/src/scripts/tx.js
@@ -1,17 +1,15 @@
 import b64 from "base64-js"
 
-const { TextEncoder, TextDecoder } = require("util");
-
 // See https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
 export const encodeBase64 = (str, encoding = 'utf-8') => {
-  let bytes = new (TextEncoder || TextEncoderLite)(encoding).encode(str)
+  let bytes = new TextEncoder(encoding).encode(str)
   return b64.fromByteArray(bytes)
 }
 
 // See https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
 export const decodeBase64 = (str, encoding = 'utf-8') => {
   let bytes = b64.toByteArray(str);
-  return new (TextDecoder || TextDecoderLite)(encoding).decode(bytes)
+  return new TextDecoder(encoding).decode(bytes)
 }
 
 export const decodeTx = (base64str) => {


### PR DESCRIPTION
Text{Decoder|Encoder}Lite are not imported nor do they seem to be necessary:

```
const { TextEncoder, TextDecoder } = require("util");
```