### PR TITLE
Fix nginx shows 404 when calling e.g. /blocks directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ RUN yarn build
 
 FROM nginx:alpine
 
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /usr/src/app/dist /usr/share/nginx/html

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,16 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri /index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
Added:
```
try_files $uri /index.html;
```
to default.conf, so that routes are handled by node and not nginx.

See: https://stackoverflow.com/a/43557288